### PR TITLE
Fix location of lang files to prevent applications with localization from breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Code::make('Address')->json()->onlyOnDetail(),
 
 ## Localization
 
-If you want this package in your language, just create a json lang file in your `resources/lang/vendor/nova-google-autocomplete` folder.
+If you want this package in your language, just create a json lang file in your `/lang/vendor/nova-google-autocomplete` folder.
 
 ## Changelog
 

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -12,7 +12,7 @@ class FieldServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../resources/lang' => resource_path('lang/vendor/nova-google-autocomplete'),
+                __DIR__.'/../resources/lang' => lang_path('/vendor/nova-google-autocomplete'),
             ], 'nova-google-autocomplete-lang');
 
             $this->publishes([
@@ -20,14 +20,13 @@ class FieldServiceProvider extends ServiceProvider
             ], 'nova-google-autocomplete-config');
         }
 
-
-        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'nova-google-autocomplete');
-        $this->loadJsonTranslationsFrom(resource_path('lang/vendor/nova-google-autocomplete'));
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'nova-google-autocomplete');
+        $this->loadJsonTranslationsFrom(lang_path('/vendor/nova-google-autocomplete'));
 
         Nova::serving(function (ServingNova $event) {
-            Nova::script('google-autocomplete', __DIR__ . '/../dist/js/field.js');
+            Nova::script('google-autocomplete', __DIR__.'/../dist/js/field.js');
             Nova::remoteScript('https://maps.googleapis.com/maps/api/js?key='.config('nova-google-autocomplete.api_key').'&libraries=places');
-            Nova::translations(resource_path('lang/vendor/nova-google-autocomplete/' . app()->getLocale() . '.json'));
+            Nova::translations(lang_path('/vendor/nova-google-autocomplete/'.app()->getLocale().'.json'));
         });
     }
 }

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -20,7 +20,7 @@ class FieldServiceProvider extends ServiceProvider
             ], 'nova-google-autocomplete-config');
         }
 
-        $this->loadTranslationsFrom(__DIR__.'/../lang', 'nova-google-autocomplete');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'nova-google-autocomplete');
         $this->loadJsonTranslationsFrom(lang_path('/vendor/nova-google-autocomplete'));
 
         Nova::serving(function (ServingNova $event) {


### PR DESCRIPTION
Laravel moved the language files with version 9 from the `/resources/lang` folder to the `/lang` folder.

Running the `php artisan vendor:publish --provider="YieldStudio\NovaGoogleAutocomplete\FieldServiceProvider"` command creates files in the `/resources/lang` folder.

The default lang path in Laravel is `/lang`. Laravel checks if any files reside in `/resources/lang` and changes the lang path to `/resources/lang` if this is true. 

This **breaks the existing application** as it can't find language files in `/lang` anymore. 

This PR fixes where the files are placed, how they are retrieved and adapts the documentation.

close #10 