### PR TITLE
Italian translation added

### DIFF
--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -1,0 +1,5 @@
+{
+    "nga_current_address": "Indirizzo corrente: :address",
+    "nga_clear": "Rimuovi",
+    "nga_search": "Cerca indirizzo"
+}


### PR DESCRIPTION
Without translation the placeholder “nga_current_address” is shown.
In this pull request the it.json file was created with the corresponding translations in Italian.